### PR TITLE
Set byteorder to big for keys (fixes build failure with Python <3.12)

### DIFF
--- a/key.py
+++ b/key.py
@@ -1,2 +1,2 @@
-AES_KEY = b''
-AES_IV = b''
+AES_KEY = bytes.fromhex('')
+AES_IV = bytes.fromhex('')


### PR DESCRIPTION
Closes #6 